### PR TITLE
docs(mcp): add OpenCode setup instructions

### DIFF
--- a/docs/mcp/overview.md
+++ b/docs/mcp/overview.md
@@ -24,6 +24,31 @@ Restart Claude Desktop. Then:
 
 > "Create a TanStack Start project called 'my-app' with Clerk auth and Drizzle ORM"
 
+## OpenCode
+
+Configuration file location:
+
+Add to `~/.config/opencode/opencode.json` (macOS/Linux) or in `C:\Users\<username>\.config\opencode\opencode.json` (Windows):
+
+```json
+{
+  "mcp": {
+    "tanstack": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@tanstack/cli",
+        "mcp"
+      ],
+      "enabled": true
+    }
+  }
+}
+```
+
+Restart OpenCode to apply changes.
+
 ## Manual Start
 
 ```bash


### PR DESCRIPTION

Added how to configure the TanStack mcp in OpenCode. 

## 🎯 Changes

Added OpenCode section in `docs/mcp/overview.md`

<!-- What changes are made in this PR? Describe the change and its motivation. -->

Hello, hello, hello!
I've seen Tanner enjoying OpenCode so I checked what's new in TanStack and I took the opportunity to add these docs. 

I verified the opencode.json paths Windows and Linux (cachyos)
And filled this template accordingly

Kind regards,
fgonzalezurriola

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/cli/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
