### PR TITLE
feat: add posthog integration and analytics category on create/builder

### DIFF
--- a/.changeset/posthog-integration.md
+++ b/.changeset/posthog-integration.md
@@ -1,0 +1,5 @@
+---
+"@tanstack/cli": minor
+---
+
+Add analytics category and posthog integration

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npx @tanstack/cli create my-app --integrations tanstack-query,clerk,drizzle
 | API | tRPC, oRPC |
 | Monitoring | Sentry |
 | i18n | Paraglide |
+| Analytics | PostHog |
 | CMS | Strapi |
 
 ## License

--- a/integrations/manifest.json
+++ b/integrations/manifest.json
@@ -495,6 +495,21 @@
       "demoRequiresTailwind": true
     },
     {
+      "id": "posthog",
+      "name": "PostHog",
+      "description": "Product analytics, session replay, and feature flags",
+      "type": "integration",
+      "category": "analytics",
+      "modes": [
+        "file-router"
+      ],
+      "dependsOn": [],
+      "hasOptions": false,
+      "link": "https://posthog.com",
+      "color": "#ff7e1b",
+      "demoRequiresTailwind": true
+    },
+    {
       "id": "mcp",
       "name": "MCP Server",
       "description": "Model Context Protocol server for AI agent integrations",

--- a/integrations/posthog/assets/src/integrations/posthog/provider.tsx
+++ b/integrations/posthog/assets/src/integrations/posthog/provider.tsx
@@ -1,0 +1,21 @@
+import posthog from 'posthog-js'
+import { PostHogProvider as BasePostHogProvider } from '@posthog/react'
+import type { ReactNode } from 'react'
+
+if (typeof window !== 'undefined' && import.meta.env.VITE_POSTHOG_KEY) {
+  posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
+    api_host:
+      import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com',
+    person_profiles: 'identified_only',
+    capture_pageview: false,
+    defaults: '2025-11-30',
+  })
+}
+
+interface PostHogProviderProps {
+  children: ReactNode
+}
+
+export function PostHogProvider({ children }: PostHogProviderProps) {
+  return <BasePostHogProvider client={posthog}>{children}</BasePostHogProvider>
+}

--- a/integrations/posthog/assets/src/routes/demo/posthog.tsx
+++ b/integrations/posthog/assets/src/routes/demo/posthog.tsx
@@ -1,0 +1,93 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { usePostHog } from '@posthog/react'
+import { useState } from 'react'
+
+export const Route = createFileRoute('/demo/posthog')({
+  component: PostHogDemo,
+})
+
+function PostHogDemo() {
+  const posthog = usePostHog()
+  const [eventCount, setEventCount] = useState(0)
+  const posthogKey = import.meta.env.VITE_POSTHOG_KEY
+  const isConfigured = Boolean(posthogKey) && posthogKey !== 'phc_xxx'
+
+  const trackEvent = (
+    eventName: string,
+    properties?: Record<string, unknown>
+  ) => {
+    posthog.capture(eventName, properties)
+    setEventCount((c) => c + 1)
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white p-8">
+      <div className="max-w-md mx-auto">
+        <h1 className="text-3xl font-bold mb-6">PostHog Demo</h1>
+
+        {!isConfigured && (
+          <div className="mb-4 p-4 bg-yellow-900/50 border border-yellow-600 rounded-lg">
+            <p className="text-yellow-200 text-sm">
+              <strong>Warning:</strong> VITE_POSTHOG_KEY is not configured.
+              Events won't be sent to PostHog. Add it to your{' '}
+              <code className="bg-yellow-900 px-1 rounded">.env</code> file.
+            </p>
+          </div>
+        )}
+
+        <div className="bg-gray-800 rounded-lg p-6">
+          <p className="text-gray-400 mb-4">
+            Click the button below to send events to PostHog. Check your
+            PostHog dashboard to see them appear in real-time.
+          </p>
+
+          <button
+            onClick={() => trackEvent('button_clicked', { button: 'demo' })}
+            className="w-full bg-cyan-600 hover:bg-cyan-700 px-4 py-3 rounded font-medium"
+          >
+            Track Click
+          </button>
+
+          {isConfigured && (
+            <div className="mt-6 p-4 bg-gray-700 rounded">
+              <p className="text-sm text-gray-400">Events sent this session:</p>
+              <p className="text-4xl font-bold text-cyan-400">{eventCount}</p>
+            </div>
+          )}
+        </div>
+
+        <p className="mt-4 text-sm text-gray-400">
+          Open your{' '}
+          <a
+            href="https://app.posthog.com/events"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-cyan-400 hover:text-cyan-300 underline"
+          >
+            PostHog Events
+          </a>{' '}
+          page to see these events appear.
+        </p>
+
+        <p className="mt-2 text-sm text-gray-400">
+          Learn more in the{' '}
+          <a
+            href="https://posthog.com/docs/libraries/react"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-cyan-400 hover:text-cyan-300 underline"
+          >
+            PostHog React docs
+          </a>
+          .
+        </p>
+
+        <div className="mt-8">
+          <Link to="/" className="text-cyan-400 hover:text-cyan-300">
+            &larr; Back to Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/integrations/posthog/files.json
+++ b/integrations/posthog/files.json
@@ -1,0 +1,4 @@
+[
+  "src/integrations/posthog/provider.tsx",
+  "src/routes/demo/posthog.tsx"
+]

--- a/integrations/posthog/info.json
+++ b/integrations/posthog/info.json
@@ -1,0 +1,49 @@
+{
+  "name": "PostHog",
+  "description": "Product analytics, session replay, and feature flags",
+  "type": "integration",
+  "phase": "integration",
+  "category": "analytics",
+  "modes": ["file-router"],
+  "priority": 20,
+  "link": "https://posthog.com",
+  "partnerId": "posthog",
+
+  "dependsOn": [],
+  "conflicts": [],
+
+  "routes": [
+    {
+      "url": "/demo/posthog",
+      "name": "PostHog",
+      "icon": "BarChart",
+      "path": "src/routes/demo/posthog.tsx",
+      "jsName": "PostHogDemo"
+    }
+  ],
+
+  "hooks": [
+    {
+      "type": "root-provider",
+      "jsName": "PostHogProvider",
+      "path": "src/integrations/posthog/provider.tsx"
+    }
+  ],
+
+  "envVars": [
+    {
+      "name": "VITE_POSTHOG_KEY",
+      "description": "Your PostHog project API key",
+      "required": true,
+      "example": "phc_xxx"
+    },
+    {
+      "name": "VITE_POSTHOG_HOST",
+      "description": "PostHog API host (for self-hosted or EU cloud)",
+      "required": false,
+      "example": "https://us.i.posthog.com"
+    }
+  ],
+
+  "gitignorePatterns": []
+}

--- a/integrations/posthog/package.json
+++ b/integrations/posthog/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "posthog-js": "^1.335.4",
+    "@posthog/react": "^1.7.0"
+  }
+}

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -94,6 +94,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   api: 'API',
   i18n: 'Internationalization',
   cms: 'CMS',
+  analytics: 'Analytics',
   other: 'Other',
 }
 
@@ -108,6 +109,7 @@ const CATEGORY_ORDER = [
   'tooling',
   'i18n',
   'cms',
+  'analytics',
   'other',
 ]
 
@@ -383,7 +385,7 @@ export async function runCreate(
     const fullPath = resolve(targetDir, filePath)
     const dir = resolve(fullPath, '..')
     mkdirSync(dir, { recursive: true })
-    
+
     // Handle binary files (base64 encoded with prefix)
     if (content.startsWith(BINARY_PREFIX)) {
       const base64Data = content.slice(BINARY_PREFIX.length)

--- a/packages/cli/src/engine/types.ts
+++ b/packages/cli/src/engine/types.ts
@@ -12,6 +12,7 @@ export const CategorySchema = z.enum([
   'deploy',
   'tooling',
   'monitoring',
+  'analytics',
   'api',
   'i18n',
   'cms',


### PR DESCRIPTION
## 🎯 Changes

* Added PostHog as a new integration.
* Added "Analytics" category in the CLI.

**Documentation and metadata:**

* Added PostHog the README to list as an available analytics integration.
* Added Changeset with what was done.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/cli/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).

## Related
- TanStack/tanstack.com#685
