### PR TITLE
fix: correct repo reference in changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
   "changelog": [
     "@svitejs/changesets-changelog-github-compact",
-    { "repo": "TanStack/pacer" }
+    { "repo": "TanStack/cli" }
   ],
   "commit": false,
   "access": "public",


### PR DESCRIPTION
## 🎯 Changes

The `.changeset/config.json` had an incorrect repo referencE. Updated to point to `TanStack/cli`. 

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/cli/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).
